### PR TITLE
fix: Allow the app to run locally again

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,7 @@ const withMDX = nextMDX({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  images: { unoptimized: true },
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
 }
 


### PR DESCRIPTION
Hello @knokd-hatem and nice to e-meet you!

After pulling down your config updates for Firebase, I could not run the app locally due to an unhandled runtime error caused by a conflict between Next's image optimizer when exporting to static files. [Conflict described in Next.js docs](https://nextjs.org/docs/messages/export-image-api). 

As a quick fix, this PR disables Next's image optimizer, which I'm okay with - people should be uploading optimized screenshots anyway IMO.

Anyway, big thank you for setting up Firebase and getting the site deployed! So we're exporting the build and deploying it as a static site now, is that right?

Thanks again