### PR TITLE
edit: Reduce rendered size of Knokd logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .next/
+Thumbs.db

--- a/src/components/KnokdLogo.jsx
+++ b/src/components/KnokdLogo.jsx
@@ -5,9 +5,6 @@ import LogoNoBg from '../../public/images/knokd-logo-xl.png';
 
 export function KnokdLogo () {
   const { resolvedTheme } = useTheme();
-  const imageStyle = {
-    minWidth: '124px'
-  }
   
   return (
     <picture>
@@ -19,9 +16,9 @@ export function KnokdLogo () {
       <Image
         priority={true}
         src={LogoNoBg}
-        width={124}
-        style={imageStyle}
-        height={undefined}
+        width={undefined}
+        style={{minWidth: 79}}
+        height={28}
         alt="Knokd's company logo"
       />
     </picture>


### PR DESCRIPTION
The logo will be closer to the protocol template size, and smaller than it appears on `knokd.ca` brochure page.

<img width="401" alt="Screenshot 2024-03-02 at 12 19 00 PM" src="https://github.com/Knokd/docs.knokd.com/assets/4868816/adb9a31e-040c-4d94-9bd7-6fae33a31a3a">
