### PR TITLE
fix: Comment-out mobile navigation call-to-actions

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -237,10 +237,10 @@ export function Navigation(props) {
   return (
     <nav {...props}>
       <ul role="list">
-        <div className='flex flex-col gap-4 md:hidden'> 
+        {/* <div className='flex flex-col gap-4 md:hidden'> 
           <ExternalCTAItem primary={false} href="https://app.knokd.com/login">Log In</ExternalCTAItem>
           <ExternalCTAItem primary={true} href="https://www.knokd.ca/get-started">Get Started</ExternalCTAItem>
-        </div>
+        </div> */}
         {navigation.map((group, groupIndex) => (
           <NavigationGroup
             key={group.title}


### PR DESCRIPTION
We'll hide the two  call-to-action buttons **Login** and **Get started** from the mobile navigation. I.e. these two will be removed form the menu but still visible on larger screens in the main nav:
<img width="273" alt="Screenshot 2024-03-02 at 12 40 15 PM" src="https://github.com/Knokd/docs.knokd.com/assets/4868816/22755288-ee1d-4ebe-9bef-5cfccb2be3a4">
