### PR TITLE
Feat: A more robust comparison table

### DIFF
--- a/src/app/listings/types-of-listings/page.mdx
+++ b/src/app/listings/types-of-listings/page.mdx
@@ -51,13 +51,48 @@ Examples
   alt="Listings cateagories when you create a listing on Knokd."
 />
 
-| Listing type                     | No MLS date planned | MLS date planned but more than 3 days away | MLS date planned in less than 3 days |
-|--------------------------|---------------------|--------------------------------------------|--------------------------------------|
-| **Residential**     | Restricted          | Before 72 hour period: Restricted <br/> Within 72 hour period: Unrestricted* | Unrestricted |
-| **New construction**   | Restricted        | Before 72 hour period: Restricted <br/> Within 72 hour period: Unrestricted* | Unrestricted                          |
-| **Residential: multi-unit (4+)**  | Unrestricted        | Unrestricted                               | Unrestricted                          |
-| **New construction: multi-unit (4+)**   | Unrestricted        | Unrestricted                               | Unrestricted                          |
-
+<div className="frozen-column-container"> 
+  <div className="col-left bg-indigo-200">
+    <div>Listing type</div>
+    <div>Residential</div>
+    <div>New construction</div>
+    <div>Multi-unit residential (4+)</div>
+    <div>New construction: multi-unit (4+)</div>
+  </div>
+  <div className="col-right">
+    <table>
+      <thead>
+        <tr>
+          <th className="table-col-1 bg-indigo-200"><strong>No MLS date planned</strong></th>
+          <th className="table-col-2 bg-indigo-200"><strong>MLS date planned more than 3 days away</strong></th>
+          <th className="table-col-3 bg-indigo-200"><strong>MLS date planned in less than 3 days</strong></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td className="table-col-1 text-orange-700">Restricted</td>
+          <td className="table-col-2">Before 72 hour period: <span className="text-orange-700">Restricted</span> <br/> Within 72 hour period: <span className="text-emerald-700">Unrestricted*</span></td>
+          <td className="table-col-3 text-emerald-700">Unrestricted</td>
+        </tr>
+        <tr>
+          <td className="table-col-1 text-emerald-700">Unrestricted</td>
+          <td className="table-col-2 text-emerald-700">Unrestricted</td>
+          <td className="table-col-3 text-emerald-700">Unrestricted</td>
+        </tr>
+        <tr>
+          <td className="table-col-1 text-emerald-700">Unrestricted</td>
+          <td className="table-col-2 text-emerald-700">Unrestricted</td>
+          <td className="table-col-3 text-emerald-700">Unrestricted</td>
+        </tr>
+        <tr>
+          <td className="table-col-1 text-emerald-700">Unrestricted</td>
+          <td className="table-col-2 text-emerald-700">Unrestricted</td>
+          <td className="table-col-3 text-emerald-700">Unrestricted</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
 
 *This change will be automatically made by the Knokd system
 

--- a/src/app/listings/types-of-listings/page.mdx
+++ b/src/app/listings/types-of-listings/page.mdx
@@ -52,20 +52,20 @@ Examples
 />
 
 <div className="frozen-column-container"> 
-  <div className="col-left bg-indigo-200">
-    <div className="col-left-item font-bold pseudo-underline">Listing type</div>
-    <div className="col-left-item">Residential (1-3 units)</div>
-    <div className="col-left-item">New construction (1-3 units)</div>
-    <div className="col-left-item">Residential: multi-unit (4+)</div>
-    <div className="col-left-item">New construction: multi-unit (4+)</div>
+  <div className="col-left bg-indigo-500">
+    <div className="col-left-item text-[var(--tw-prose-headings)] font-bold pseudo-underline">Listing type</div>
+    <div className="col-left-item text-[var(--tw-prose-headings)]">Residential (1-3 units)</div>
+    <div className="col-left-item text-[var(--tw-prose-headings)]">New construction (1-3 units)</div>
+    <div className="col-left-item text-[var(--tw-prose-headings)]">Residential: multi-unit (4+)</div>
+    <div className="col-left-item text-[var(--tw-prose-headings)]">New construction: multi-unit (4+)</div>
   </div>
   <div className="col-right">
     <table>
       <thead>
         <tr>
-          <th className="table-col-1 bg-indigo-200"><strong>No MLS date planned</strong></th>
-          <th className="table-col-2 bg-indigo-200"><strong>MLS date planned more than 3 days away</strong></th>
-          <th className="table-col-3 bg-indigo-200"><strong>MLS date planned in less than 3 days</strong></th>
+          <th className="table-col-1 bg-indigo-500"><strong>No MLS date planned</strong></th>
+          <th className="table-col-2 bg-indigo-500"><strong>MLS date planned more than 3 days away</strong></th>
+          <th className="table-col-3 bg-indigo-500"><strong>MLS date planned in less than 3 days</strong></th>
         </tr>
       </thead>
       <tbody>

--- a/src/app/listings/types-of-listings/page.mdx
+++ b/src/app/listings/types-of-listings/page.mdx
@@ -53,11 +53,11 @@ Examples
 
 <div className="frozen-column-container"> 
   <div className="col-left bg-indigo-200">
-    <div>Listing type</div>
-    <div>Residential</div>
-    <div>New construction</div>
-    <div>Multi-unit residential (4+)</div>
-    <div>New construction: multi-unit (4+)</div>
+    <div className="col-left-item font-bold pseudo-underline">Listing type</div>
+    <div className="col-left-item">Residential</div>
+    <div className="col-left-item">New construction</div>
+    <div className="col-left-item">Multi-unit residential (4+)</div>
+    <div className="col-left-item">New construction: multi-unit (4+)</div>
   </div>
   <div className="col-right">
     <table>

--- a/src/app/listings/types-of-listings/page.mdx
+++ b/src/app/listings/types-of-listings/page.mdx
@@ -54,9 +54,9 @@ Examples
 <div className="frozen-column-container"> 
   <div className="col-left bg-indigo-200">
     <div className="col-left-item font-bold pseudo-underline">Listing type</div>
-    <div className="col-left-item">Residential</div>
-    <div className="col-left-item">New construction</div>
-    <div className="col-left-item">Multi-unit residential (4+)</div>
+    <div className="col-left-item">Residential (1-3 units)</div>
+    <div className="col-left-item">New construction (1-3 units)</div>
+    <div className="col-left-item">Residential: multi-unit (4+)</div>
     <div className="col-left-item">New construction: multi-unit (4+)</div>
   </div>
   <div className="col-right">
@@ -75,8 +75,8 @@ Examples
           <td className="table-col-3 text-emerald-700">Unrestricted</td>
         </tr>
         <tr>
-          <td className="table-col-1 text-emerald-700">Unrestricted</td>
-          <td className="table-col-2 text-emerald-700">Unrestricted</td>
+          <td className="table-col-1 text-orange-700">Restricted</td>
+          <td className="table-col-2">Before 72 hour period: <span className="text-orange-700">Restricted</span> <br/> Within 72 hour period: <span className="text-emerald-700">Unrestricted*</span></td>
           <td className="table-col-3 text-emerald-700">Unrestricted</td>
         </tr>
         <tr>

--- a/src/styles/custom.module.css
+++ b/src/styles/custom.module.css
@@ -60,7 +60,7 @@
 
 .table-col-2 {
   height: 100px;
-  width: clamp(200px, 320px, 390px);
+  width: clamp(200px, 230px, 390px);
   vertical-align: middle;
   text-align: center;
 }

--- a/src/styles/custom.module.css
+++ b/src/styles/custom.module.css
@@ -20,6 +20,7 @@
 /* Tables CSS */
 
 .frozen-column-container {
+  position:relative;
   margin: 0 auto;
   border: 1px solid black;
   display: flex;
@@ -48,7 +49,7 @@
 /* All cells */
 .col-right table th, .col-right table td {
   padding: 10px;
-  border: 1px solid gray;
+  border: 1px solid black;
 }
 
 .table-col-1 {
@@ -73,15 +74,33 @@
 }
 
 .col-left {
+  display: flex;
+  flex-direction: column;
   border-right: 1px solid black;
+  justify-content: center;
+
+  border-top: 1px solid black;
+  border-left: 1px solid black;
+  border-bottom: 1px solid black;
 }
 
 /* The 'fake' left table-column items */
-.col-left div {
-  padding: 10px;
+.col-left-item {
   display: flex;
+  flex: 1;
   align-items: center;
-  font-weight: bold;
-  height: 24%;
+  padding: 10px;
   width: 160px;
+}
+
+.pseudo-underline::after{
+  content: '';
+  display: block;
+  position: absolute;
+  left: 0;
+  height: 0;
+  width: 100%; /* works now because parent relative, child absolute trick*/
+  top: 100px;
+  border: 1px solid black;
+  box-shadow: none;
 }

--- a/src/styles/custom.module.css
+++ b/src/styles/custom.module.css
@@ -72,6 +72,10 @@
   text-align: center;
 }
 
+.col-left {
+  border-right: 1px solid black;
+}
+
 /* The 'fake' left table-column items */
 .col-left div {
   padding: 10px;

--- a/src/styles/custom.module.css
+++ b/src/styles/custom.module.css
@@ -49,7 +49,7 @@
 /* All cells */
 .col-right table th, .col-right table td {
   padding: 10px;
-  border: 1px solid black;
+  border: 1px solid var(--tw-prose-headings) ;
 }
 
 .table-col-1 {
@@ -76,12 +76,12 @@
 .col-left {
   display: flex;
   flex-direction: column;
-  border-right: 1px solid black;
+  border-right: 1px solid var(--tw-prose-headings);
   justify-content: center;
 
-  border-top: 1px solid black;
-  border-left: 1px solid black;
-  border-bottom: 1px solid black;
+  border-top: 1px solid var(--tw-prose-headings);
+  border-left: 1px solid var(--tw-prose-headings);
+  border-bottom: 1px solid var(--tw-prose-headings);
 }
 
 /* The 'fake' left table-column items */
@@ -101,6 +101,6 @@
   height: 0;
   width: 100%; /* works now because parent relative, child absolute trick*/
   top: 100px;
-  border: 1px solid black;
+  border: 1px solid var(--tw-prose-headings);
   box-shadow: none;
 }

--- a/src/styles/custom.module.css
+++ b/src/styles/custom.module.css
@@ -16,3 +16,68 @@
   background-color: #5344ed;
   outline: 2px solid #5344ed;
 }
+
+/* Tables CSS */
+
+.frozen-column-container {
+  margin: 0 auto;
+  border: 1px solid black;
+  display: flex;
+  flex-direction: row;
+}
+
+/* Margin needs a reset */ 
+.frozen-column-container table {
+  margin: 0;
+}
+
+/* The table container */
+.col-right {
+  /* Tables are not block elements, so need to 
+  apply the overflow on a div containing the table */
+  overflow-x: auto;
+}
+
+/* The table */
+.col-right table {
+  /* This is required to respect the custom
+  column widths in table-col-x classes */
+  table-layout: fixed;
+}
+
+/* All cells */
+.col-right table th, .col-right table td {
+  padding: 10px;
+  border: 1px solid gray;
+}
+
+.table-col-1 {
+  height: 100px;
+  width: clamp(100px, 150px, 200px);
+  vertical-align: middle;
+  text-align: center;
+}
+
+.table-col-2 {
+  height: 100px;
+  width: clamp(200px, 320px, 390px);
+  vertical-align: middle;
+  text-align: center;
+}
+
+.table-col-3 {
+  height: 100px;
+  width: clamp(100px, 150px, 200px);
+  vertical-align: middle;
+  text-align: center;
+}
+
+/* The 'fake' left table-column items */
+.col-left div {
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+  height: 24%;
+  width: 160px;
+}


### PR DESCRIPTION
Hey @andrewpaliga I remember on our last call you said you didn't love the table at https://docs.knokd.com/listings/types-of-listings. I took a look today and saw that especially on mobile it didn't behave well. I got into a bit of a can of worms with tables as I wanted to make the left column sticky, and came up with this hybrid flexbox + nested table solution.

Technically this is a bit less a11y-friendly than a plain table, but it fixes an actual layout issue and adds the sticky left column with scrollable table feature.

The color choices would need a design review, I threw some in there so you can see it's customizable. Have a look at the firebase preview link as well to see the scrollbar appear on smaller screens. edit: [here's the preview link](https://knokd-docs-30d6e--pr14-friendlier-tables-ps8p9bs5.web.app/listings/types-of-listings#unrestricted-listings)

<img width="272" alt="Screenshot 2024-04-27 at 4 44 13 PM" src="https://github.com/Knokd/docs.knokd.com/assets/4868816/b32cedbe-4ae3-4acc-8d33-978ae1c20f94">


