### PR TITLE
Use colors within the palette

### DIFF
--- a/src/app/listings/types-of-listings/page.mdx
+++ b/src/app/listings/types-of-listings/page.mdx
@@ -52,7 +52,7 @@ Examples
 />
 
 <div className="frozen-column-container"> 
-  <div className="col-left bg-indigo-500">
+  <div className="col-left bg-indigo-300">
     <div className="col-left-item text-[var(--tw-prose-headings)] font-bold pseudo-underline">Listing type</div>
     <div className="col-left-item text-[var(--tw-prose-headings)]">Residential (1-3 units)</div>
     <div className="col-left-item text-[var(--tw-prose-headings)]">New construction (1-3 units)</div>
@@ -63,31 +63,31 @@ Examples
     <table>
       <thead>
         <tr>
-          <th className="table-col-1 bg-indigo-500"><strong>No MLS date planned</strong></th>
-          <th className="table-col-2 bg-indigo-500"><strong>MLS date planned more than 3 days away</strong></th>
-          <th className="table-col-3 bg-indigo-500"><strong>MLS date planned in less than 3 days</strong></th>
+          <th className="table-col-1 bg-indigo-300"><strong>No MLS date planned</strong></th>
+          <th className="table-col-2 bg-indigo-300"><strong>MLS date planned more than 3 days away</strong></th>
+          <th className="table-col-3 bg-indigo-300"><strong>MLS date planned in less than 3 days</strong></th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td className="table-col-1 text-orange-700">Restricted</td>
-          <td className="table-col-2">Before 72 hour period: <span className="text-orange-700">Restricted</span> <br/> Within 72 hour period: <span className="text-emerald-700">Unrestricted*</span></td>
-          <td className="table-col-3 text-emerald-700">Unrestricted</td>
+          <td className="table-col-1 text-yellow-700">Restricted</td>
+          <td className="table-col-2">Before 72 hour period: <span className="text-yellow-700">Restricted</span> <br/> Within 72 hour period: <span className="text-green-700">Unrestricted*</span></td>
+          <td className="table-col-3 text-green-700">Unrestricted</td>
         </tr>
         <tr>
-          <td className="table-col-1 text-orange-700">Restricted</td>
-          <td className="table-col-2">Before 72 hour period: <span className="text-orange-700">Restricted</span> <br/> Within 72 hour period: <span className="text-emerald-700">Unrestricted*</span></td>
-          <td className="table-col-3 text-emerald-700">Unrestricted</td>
+          <td className="table-col-1 text-yellow-700">Restricted</td>
+          <td className="table-col-2">Before 72 hour period: <span className="text-yellow-700">Restricted</span> <br/> Within 72 hour period: <span className="text-green-700">Unrestricted*</span></td>
+          <td className="table-col-3 text-green-700">Unrestricted</td>
         </tr>
         <tr>
-          <td className="table-col-1 text-emerald-700">Unrestricted</td>
-          <td className="table-col-2 text-emerald-700">Unrestricted</td>
-          <td className="table-col-3 text-emerald-700">Unrestricted</td>
+          <td className="table-col-1 text-green-700">Unrestricted</td>
+          <td className="table-col-2 text-green-700">Unrestricted</td>
+          <td className="table-col-3 text-green-700">Unrestricted</td>
         </tr>
         <tr>
-          <td className="table-col-1 text-emerald-700">Unrestricted</td>
-          <td className="table-col-2 text-emerald-700">Unrestricted</td>
-          <td className="table-col-3 text-emerald-700">Unrestricted</td>
+          <td className="table-col-1 text-green-700">Unrestricted</td>
+          <td className="table-col-2 text-green-700">Unrestricted</td>
+          <td className="table-col-3 text-green-700">Unrestricted</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
This PR updates 3 colors in the Listing Types table

- background: bg-indigo-300
- restricted: text-yellow-700
- unrestricted: text-green-700

And looks like this

<img width="495" alt="Screenshot 2024-05-08 at 1 11 20 AM" src="https://github.com/Knokd/docs.knokd.com/assets/4868816/76870408-737e-47cb-841d-52188dab166a">

@andrewpaliga the indigo shade from the issue was actually bg-indigo-200 if you still prefer that, we just need to find + replace `bg-indigo-300` with `bg-indigo-200`.

I won't merge since I can't revert for a few hours, but we'll chat soon. Thanks for the slack messages too I'll implement those content changes in another PR
