### PR TITLE
fix: update the color of the sidebar flag on active doc to indigo

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -92,7 +92,7 @@ function ActivePageMarker({ group, pathname }) {
   return (
     <motion.div
       layout
-      className="absolute left-2 h-6 w-px bg-emerald-500"
+      className="absolute left-2 h-6 w-px bg-indigo-500"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1, transition: { delay: 0.2 } }}
       exit={{ opacity: 0 }}


### PR DESCRIPTION
The active doc has a thin flag to show that's is currently selected. The color was emerald from the tailwind ui template, so this just makes it on brand with indigo.

<img width="285" alt="Screenshot 2024-05-09 at 12 16 01 AM" src="https://github.com/Knokd/docs.knokd.com/assets/4868816/3228ce70-aa9a-4b45-b4ba-95562e683a3b">
