### PR TITLE
Remove the catchall disallow rule

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
-Disallow: /
 Disallow: /template_docs


### PR DESCRIPTION
@andrewpaliga Feel free to merge this if you want search engines to start indexing the whole docs site.