### PR TITLE
Pick one email announcement (and style fixes)

### DIFF
--- a/src/app/marketing-resources/newsletters-and-emails/page.mdx
+++ b/src/app/marketing-resources/newsletters-and-emails/page.mdx
@@ -19,15 +19,15 @@ export const sections = [
 
 Here are some email content pieces that you can send to your agents and clients to inform them about Knokd. {{ className: 'lead' }}
 
-Recommended use: Copy and paste these templates, customise them with [your sign-up link](/contacts/add-contacts#sign-up-link), and share them with your email database. Replace any content between square brackets `[` and `]` with your relevant info.
+Recommended use: Copy and paste these templates, customise them with [your sign-up link](/contacts/add-contacts#sign-up-link), and share them with your email database. Replace any placeholder content [between square brackets] with your real info.
 
 
 
 ## Announcement to clients
 
-**Version 1 of 2**
+1. [Find your personal sign-up link](/contacts/add-contacts#sign-up-link).
 
-Highlight, copy and paste our content. Replace anthing [inside square brackets] with your info:
+2. Highlight, copy and paste our content. Replace anthing [inside square brackets] with your info:
 
 <MarketingMaterial>
 Hi [first name],
@@ -41,46 +41,14 @@ I’ve partnered with Knokd to give you access to all Coming Soon, Exclusive and
 All you need to do is set up a search for the home that you are looking for and I will do the rest. If I come across matches for your search, Knokd will help me share them with you as soon as possible.
 
 If you have any questions please let me know,
-[Your Name Here]
-</MarketingMaterial>
-
-**Version 2 of 2:**
-
-Highlight, copy and paste our content. Replace anthing [inside square brackets] with your info:
-
-<MarketingMaterial>
-Hi there,
-
-I am excited to announce that I am offering a new tool to all my clients: [Knokd](https://knokd.com)!
-
-For the very first time, Knokd is providing Home Buyers and Sellers with access to the off-market!
-
-The off-market includes properties that are Coming Soon or Exclusive and cannot be found on the MLS® or any other portal. In fact, 1 in 3 properties are listed in the off-market and may not ever be listed publicly.
-
-I want to provide you with special access to this hidden off-market inventory.
-
-With Knokd you can:
-  * Browse the entire off-market inventory in Ottawa
-  * Gain first access to off-market properties
-  * Collaborate with me to easily express interest in off-market properties
-  * Gauge the market and test pricing for your home listing without listing it on the MLS®
-  * Boost exposure and increase marketing for your home listing
-  * Share your home discreetly, without listing it on the MLS®
-
-Click here to get access to Knokd today! [Insert your personal landing page link here]
-
-I’m looking forward to providing this exclusive access to you all. If you have any questions, please contact me or the [Knokd team here](https://direct.lc.chat/13256475/).
-
-Sincerely,
-
-[Your Name Here]
+[Your name here]
 
 </MarketingMaterial>
 
 ## Newsletter snippet
-[Get your personal sign-up link](/contacts/add-contacts#sign-up-link)
+1. [Find your personal sign-up link](/contacts/add-contacts#sign-up-link).
 
-Highlight, copy and paste our content. Replace anthing [inside square brackets] with your info:
+2. Highlight, copy and paste our content. Replace anthing [inside square brackets] with your info:
 
 <MarketingMaterial>
 Special Access Alert! 🚨

--- a/src/app/marketing-resources/newsletters-and-emails/page.mdx
+++ b/src/app/marketing-resources/newsletters-and-emails/page.mdx
@@ -53,7 +53,7 @@ If you have any questions please let me know,
 <MarketingMaterial>
 Special Access Alert! 🚨
 <br/>As my client, you now have access to Knokd, the off-market Real Estate platform! Knokd’s network offers insider access to off-market properties that aren’t found on any other portal, unique exposure for listings, and enticing market insights.
-<br/>Click here to get access to the off-market [Insert your personal [landing page link here](/contacts/add-contacts#sign-up-link)]
+<br/>Click here to get access to the off-market [Insert your personal [sign-up link here](/contacts/add-contacts#sign-up-link)]
 
 </MarketingMaterial>
 

--- a/src/components/MarketingMaterial.jsx
+++ b/src/components/MarketingMaterial.jsx
@@ -102,7 +102,7 @@ export function MarketingMaterial ({children}) {
 
   return (
     <div className=" mx-auto relative bg-slate-700 rounded p-4 list-reset">
-      <pre className="overflow-hidden text-wrap p-4 text-xs text-white">{children}</pre>
+      <pre className="overflow-hidden text-wrap p-4 text-xs text-white reset-margin-first-p">{children}</pre>
       {/* <MarketingCopyButton children={children}/> */}
     </div>
   )

--- a/src/styles/custom.module.css
+++ b/src/styles/custom.module.css
@@ -134,3 +134,9 @@
 .list-reset p {
   margin-bottom: 0;
 }
+
+/* Marketing Material */
+
+.reset-margin-first-p p:nth-child(1) {
+  margin: 0;
+}


### PR DESCRIPTION
This PR:
- Removes the 2nd, long-form client announcement that had the bulleted list.
- Includes a hot fix to remove some unwanted whitespace in the MarketingMaterial component. Specifically, it removes the margin-top from the first paragraph, shown in orange here:
<img width="665" alt="Screenshot 2024-05-14 at 9 44 17 AM" src="https://github.com/Knokd/docs.knokd.com/assets/4868816/9254be7e-1957-435a-99f1-6d6dcbeff4f7">
- Includes some styleguide changes.

@andrewpaliga if you all agree to remove the 2nd email content (the long one with bulleted list) you can merge this PR. If you're keeping it though, I'll get some of these changes in to fix styles, but don't merge this PR yet.